### PR TITLE
packagist only supporting small letters. Lets add

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Aura/Uri",
+    "name": "aura/uri",
     "type": "library",
     "description": "The Aura Uri package provides objects to build and manipulate URI strings.",
     "keywords": [


### PR DESCRIPTION
aura/uri to packagist, so next release will get the Aura.Uri
