### PR TITLE
Adds phpunit filter to allow both code coverage and use of full psl array in tests

### DIFF
--- a/tests/Aura/Uri/CheckPublicSuffixTest.php
+++ b/tests/Aura/Uri/CheckPublicSuffixTest.php
@@ -3,9 +3,9 @@
 namespace Aura\Uri;
 
 /**
- * This test case is based on the test data linked at 
+ * This test case is based on the test data linked at
  * http://publicsuffix.org/list/ and provided by Rob Strading of Comodo.
- * @link 
+ * @link
  * http://mxr.mozilla.org/mozilla-central/source/netwerk/test/unit/data/test_psl.txt?raw=1
  */
 class CheckPublicSuffixTest extends \PHPUnit_Framework_TestCase
@@ -18,33 +18,10 @@ class CheckPublicSuffixTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->psl = new PublicSuffixList([
-            'ac' => [],
-            'biz' => [],
-            'com' => [
-                'uk' => [],
-            ],
-            'cy' => [
-                'c' => [],
-            ],
-            'jp' => [
-                'ac' => [],
-                'kyoto' => [
-                    'ide' => [],
-                ],
-                'kobe' => [
-                    'c' => [],
-                ],
-            ],
-            'om' => [
-                'test' => [],
-            ],
-            'us' => [
-                'ak' => [
-                    'k12' => [],
-                ],
-            ],
-        ]);
+        $file = dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR
+              . 'data' . DIRECTORY_SEPARATOR
+              . 'public-suffix-list.php';
+        $this->psl = new PublicSuffixList(require $file);
     }
 
     public function testPublicSuffixSpec()
@@ -126,11 +103,11 @@ class CheckPublicSuffixTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * This is my version of the checkPublicSuffix function referred to in the 
+     * This is my version of the checkPublicSuffix function referred to in the
      * test instructions at the Public Suffix List project.
      *
-     * "You will need to define a checkPublicSuffix() function which takes as a 
-     * parameter a domain name and the public suffix, runs your implementation 
+     * "You will need to define a checkPublicSuffix() function which takes as a
+     * parameter a domain name and the public suffix, runs your implementation
      * on the domain name and checks the result is the public suffix expected."
      *
      * @link http://publicsuffix.org/list/

--- a/tests/Aura/Uri/HostTest.php
+++ b/tests/Aura/Uri/HostTest.php
@@ -13,38 +13,12 @@ class HostTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $list = new PublicSuffixList([
-            'au' => [
-                'com' => [],
-            ],
-            'com' => [
-                'uk' => [],
-            ],
-            'cy' => [
-                'c' => [],
-            ],
-            'il' => [
-                'co' => [],
-            ],
-            'jp' => [
-                'kyoto' => [
-                    'ide' => [],
-                ],
-            ],
-            'om' => [
-                'test' => [],
-            ],
-            'uk' => [
-                'co' => [],
-            ],
-            'us' => [
-                'ak' => [
-                    'k12' => [],
-                ],
-            ],
-        ]);
+        $file = dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR
+              . 'data' . DIRECTORY_SEPARATOR
+              . 'public-suffix-list.php';
+        $psl = new PublicSuffixList(require $file);
 
-        $this->host = new Host($list);
+        $this->host = new Host($psl);
     }
 
     protected function tearDown()

--- a/tests/Aura/Uri/PublicSuffixListTest.php
+++ b/tests/Aura/Uri/PublicSuffixListTest.php
@@ -12,36 +12,10 @@ class PublicSuffixListTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->psl = new PublicSuffixList([
-            'au' => [
-                'com' => [],
-            ],
-            'com' => [
-                'uk' => [],
-            ],
-            'cy' => [
-                'c' => [],
-            ],
-            'il' => [
-                'co' => [],
-            ],
-            'jp' => [
-                'kyoto' => [
-                    'ide' => [],
-                ],
-            ],
-            'om' => [
-                'test' => [],
-            ],
-            'uk' => [
-                'co' => [],
-            ],
-            'us' => [
-                'ak' => [
-                    'k12' => [],
-                ],
-            ],
-        ]);
+        $file = dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR
+              . 'data' . DIRECTORY_SEPARATOR
+              . 'public-suffix-list.php';
+        $this->psl = new PublicSuffixList(require $file);
     }
 
     /**
@@ -67,7 +41,7 @@ class PublicSuffixListTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertSame($subdomain, $this->psl->getSubdomain($hostPart));
     }
-    
+
 	/**
      * @dataProvider parseDataProvider
 	 */
@@ -96,5 +70,5 @@ class PublicSuffixListTest extends \PHPUnit_Framework_TestCase
             array('politics.news.omanpost.om', 'om', 'omanpost.om', 'politics.news', 'politics.news.omanpost.om'),
         );
     }
-	
+
 }

--- a/tests/Aura/Uri/UrlTest.php
+++ b/tests/Aura/Uri/UrlTest.php
@@ -17,7 +17,7 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      * @var Url
      */
     protected $url;
-    
+
     /**
      * @var string Url spec
      */
@@ -61,8 +61,8 @@ class UrlTest extends \PHPUnit_Framework_TestCase
             new Host(
                 $this->psl,
                 [
-                'subdomain' => null, 
-                'registerableDomain' => 'example.com', 
+                'subdomain' => null,
+                'registerableDomain' => 'example.com',
                 'publicSuffix' => 'com'
                 ]
             ),
@@ -71,10 +71,10 @@ class UrlTest extends \PHPUnit_Framework_TestCase
             new Query(['baz' => 'dib', 'zim' => 'gir']),
             'fragment'
         );
-        
+
         $this->assertInstanceOf('Aura\Uri\Url', $url);
     }
-    
+
     /**
      * @covers Aura\Uri\Url::__toString
      */

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,7 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="./bootstrap.php">
     <testsuites>
         <testsuite>
             <directory>./Aura/Uri</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">../src/Aura/Uri</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
I was able to run `phpunit -d memory_limit=128M --coverage-html tests/log/coverage-html` without running out of memory.

Alternate resolution to #15.
