### PR TITLE
Adds support for schemeless URLs and for ftp/ftps schemes

### DIFF
--- a/src/Aura/Uri/Url.php
+++ b/src/Aura/Uri/Url.php
@@ -20,6 +20,11 @@ namespace Aura\Uri;
 class Url
 {
     /**
+     * Pattern for URL scheme matching
+     */
+    const SCHEME_PATTERN = '#^https?://#i';
+
+    /**
      *
      * The scheme (for example 'http' or 'https').
      *
@@ -209,6 +214,18 @@ class Url
               . (empty($this->port) ? '' : ':' . (int) $this->port);
 
         return $url . $this->get();
+    }
+
+    /**
+     *
+     * Returns the URL as a string, including the host but excluding the scheme
+     *
+     * @return string The URL string.
+     *
+     */
+    public function getSchemeless()
+    {
+        return preg_replace(self::SCHEME_PATTERN, '//', $this->getFull(), 1);
     }
 
     /**

--- a/src/Aura/Uri/Url.php
+++ b/src/Aura/Uri/Url.php
@@ -22,7 +22,7 @@ class Url
     /**
      * Pattern for URL scheme matching
      */
-    const SCHEME_PATTERN = '#^https?://#i';
+    const SCHEME_PATTERN = '#^(http|ftp)s?://#i';
 
     /**
      *

--- a/src/Aura/Uri/Url/Factory.php
+++ b/src/Aura/Uri/Url/Factory.php
@@ -149,8 +149,10 @@ class Factory
      */
     public function parse($spec)
     {
-        if (strpos($spec, 'http') !== 0) {
-            $spec = 'http://' . $spec;
+        preg_match(Url::SCHEME_PATTERN, $spec, $schemeMatches);
+
+        if (empty($schemeMatches)) {
+            $spec = 'http://' . preg_replace('#^//#', '', $spec, 1);
         }
 
         return parse_url($spec);

--- a/tests/Aura/Uri/Url/FactoryTest.php
+++ b/tests/Aura/Uri/Url/FactoryTest.php
@@ -123,4 +123,13 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $expect = 'http://example.com';
         $this->assertSame($expect, $actual);
     }
+
+    public function testNewInstance_ftpUrl()
+    {
+        $factory = $this->newFactory([]);
+        $string = 'ftp://ftp.example.com';
+        $url = $factory->newInstance($string);
+        $actual = $url->__toString();
+        $this->assertSame($string, $actual);
+    }
 }

--- a/tests/Aura/Uri/Url/FactoryTest.php
+++ b/tests/Aura/Uri/Url/FactoryTest.php
@@ -113,4 +113,14 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
         $expect = 'http://example.com';
         $this->assertSame($expect, $actual);
     }
+
+    public function testNewInstance_schemeless()
+    {
+        $factory = $this->newFactory([]);
+        $string = '//example.com';
+        $url = $factory->newInstance($string);
+        $actual = $url->__toString();
+        $expect = 'http://example.com';
+        $this->assertSame($expect, $actual);
+    }
 }

--- a/tests/Aura/Uri/UrlTest.php
+++ b/tests/Aura/Uri/UrlTest.php
@@ -2,10 +2,6 @@
 namespace Aura\Uri;
 
 use Aura\Uri\Url\Factory as UrlFactory;
-use Aura\Uri\Path;
-use Aura\Uri\Query;
-use Aura\Uri\Host;
-use Aura\Uri\PublicSuffixList;
 
 /**
  * Test class for Url.
@@ -120,6 +116,16 @@ class UrlTest extends \PHPUnit_Framework_TestCase
     {
         $actual = $this->url->getFull();
         $this->assertSame($this->spec, $actual);
+    }
+
+    /**
+     * @covers Aura\Uri\Url::getSchemeless
+     */
+    public function testGetSchemeless()
+    {
+        $schemeless = substr_replace($this->spec, '', 0, 5);
+        $actual = $this->url->getSchemeless();
+        $this->assertSame($schemeless, $actual);
     }
 
     /**


### PR DESCRIPTION
Not sure if you've received any requests for these features, but I did in php-domain-parser.  I figured I'd pass 'em along.
